### PR TITLE
Simple validation

### DIFF
--- a/lib/validation.ex
+++ b/lib/validation.ex
@@ -15,12 +15,10 @@ defmodule Validation do
     end
   end
 
-  def result(params, _schema) do
-    # Dummy for now
-    %{
-      errors: %{},
-      valid?: true,
-      data: params
-    }
+  @doc """
+  Shorthand for Validation.Validator.result/2
+  """
+  def result(params, schema) do
+    Validation.Validator.result(params, schema)
   end
 end

--- a/lib/validation/predicates.ex
+++ b/lib/validation/predicates.ex
@@ -1,0 +1,29 @@
+defmodule Validation.Predicates do
+  @moduledoc """
+  Built-in predicates
+  """
+
+  def filled?(value) do
+    !empty(value)
+  end
+
+  def empty(%{}), do: true
+  def empty([]), do: true
+  def empty(""), do: true
+  def empty(nil), do: true
+  def empty(_), do: false
+
+  def type?(value, :string) when is_binary(value), do: true
+  def type?(_value, :string), do: false
+
+  def match?(value, pattern) when is_binary(value) do
+    if pattern |> Regex.regex? do
+      value |> String.match?(pattern)
+    else
+      false
+    end
+  end
+  def match?(_, _) do
+    false
+  end
+end

--- a/lib/validation/predicates.ex
+++ b/lib/validation/predicates.ex
@@ -17,11 +17,7 @@ defmodule Validation.Predicates do
   def type?(_value, :string), do: false
 
   def match?(value, pattern) when is_binary(value) do
-    if pattern |> Regex.regex? do
-      value |> String.match?(pattern)
-    else
-      false
-    end
+    value |> String.match?(pattern)
   end
   def match?(_, _) do
     false

--- a/lib/validation/result.ex
+++ b/lib/validation/result.ex
@@ -1,0 +1,21 @@
+defmodule Validation.Result do
+  @moduledoc """
+  The result of a validation
+  """
+
+  defstruct [
+    data: %{},
+    errors: %{}
+  ]
+
+  def valid?(result) do
+    result.errors == %{}
+  end
+
+  @doc """
+  Adds a parameter to the data.
+  """
+  def put_data(result, key, value) do
+    %{result | data: Map.put(result.data, key, value)}
+  end
+end

--- a/lib/validation/result.ex
+++ b/lib/validation/result.ex
@@ -18,4 +18,11 @@ defmodule Validation.Result do
   def put_data(result, key, value) do
     %{result | data: Map.put(result.data, key, value)}
   end
+
+  @doc """
+  Adds an error to a specific key
+  """
+  def put_error(result, key, message) do
+    %{result | errors: Map.update(result.errors, key, [message], fn errors -> [message | errors] end)}
+  end
 end

--- a/lib/validation/validator.ex
+++ b/lib/validation/validator.ex
@@ -27,10 +27,15 @@ defmodule Validation.Validator do
           result
           |> Result.put_data(key, value)
           |> Result.put_error(key, message)
+        :no_rule ->
+          result
       end
     end)
   end
 
+  defp validate_param(_value, nil) do
+    :no_rule
+  end
   defp validate_param(value, rule) do
     validate_predicate(value, rule.value_predicates)
   end

--- a/lib/validation/validator.ex
+++ b/lib/validation/validator.ex
@@ -16,9 +16,30 @@ defmodule Validation.Validator do
       |> Enum.map(&({&1.field, &1}))
       |> Enum.into(%{})
 
+    %Result{}
+    |> validate_keys(params, schema.rules)
+    |> validate_values(params, rule_map)
+  end
+
+  defp validate_keys(result, params, rules) do
+    rules
+    |> Enum.reduce(result, fn
+        %{key_rule: :optional}, result ->
+          result
+        rule, result ->
+          if Map.has_key?(params, rule.field) do
+            result
+          else
+            result
+            |> Result.put_error(rule.field, "is missing")
+          end
+    end)
+  end
+
+  defp validate_values(result, params, rule_map) do
     params
     |> Enum.into([])
-    |> Enum.reduce(%Result{}, fn {key, value}, result ->
+    |> Enum.reduce(result, fn {key, value}, result ->
       case validate_param(value, Map.get(rule_map, key)) do
         :ok ->
           result

--- a/lib/validation/validator.ex
+++ b/lib/validation/validator.ex
@@ -1,0 +1,26 @@
+defmodule Validation.Validator do
+  @moduledoc """
+  functions for validating a set of params against a schema
+  """
+
+  alias Validation.Result
+
+  @doc """
+  Validates a set of params against a schema.
+  Returns a Validation.Result struct
+  """
+  def result(params, schema) do
+    params
+    |> Enum.into([])
+    |> Enum.reduce(%Result{}, fn {key, value} = param, result ->
+      case validate_param(param, schema) do
+        :ok ->
+          Result.put_data(result, key, value)
+      end
+    end)
+  end
+
+  def validate_param({_key, _value}, _schema) do
+    :ok
+  end
+end

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -5,6 +5,8 @@ defmodule ValidationTest do
   """
 
   use ExUnit.Case, async: true
+
+  alias Validation.Result
   require Validation
 
   def name_email_schema do
@@ -14,18 +16,17 @@ defmodule ValidationTest do
     end
   end
 
-  @tag :skip
   test "basic usage with valid params" do
     params = %{
-      "name" => "Chuck Norris",
-      "email" => "gmail@chucknorris.com"
+      name: "Chuck Norris",
+      email: "gmail@chucknorris.com"
     }
 
     result = Validation.result(params, name_email_schema)
 
     assert result.errors == %{}
-    assert result.valid? == true
     assert result.data == %{name: "Chuck Norris", email: "gmail@chucknorris.com"}
+    assert Result.valid?(result) == true
   end
 
   @tag :skip

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -11,8 +11,8 @@ defmodule ValidationTest do
 
   def name_email_schema do
     Validation.schema do
-      optional(:name, filled? and string?)
-      required(:email, filled? and string? and match?(~r/@/))
+      optional(:name, filled? and type?(:string))
+      required(:email, filled? and type?(:string) and match?(~r/@/))
     end
   end
 
@@ -29,8 +29,19 @@ defmodule ValidationTest do
     assert Result.valid?(result) == true
   end
 
-  @tag :skip
-  test "basic usage with invalid params"
+  test "basic usage with invalid params" do
+    params = %{
+      name: "Derp",
+      email: "Derp"
+    }
+
+    result = Validation.result(params, name_email_schema)
+
+    assert result.errors == %{email: ["is invalid"]}
+    assert result.data == %{name: "Derp", email: "Derp"}
+    assert Result.valid?(result) == false
+  end
+
   @tag :skip
   test "whitelisting params"
   @tag :skip

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -55,6 +55,25 @@ defmodule ValidationTest do
     assert result.data == %{name: "Chuck Norris", email: "gmail@chucknorris.com"}
   end
 
-  @tag :skip
-  test "optional params"
+  test "missing required params" do
+    params = %{
+      name: "Derp With No Email"
+    }
+
+    result = Validation.result(params, name_email_schema)
+
+    assert result.errors == %{email: ["is missing"]}
+    assert result.data == %{name: "Derp With No Email"}
+  end
+
+  test "missing optional params" do
+    params = %{
+      email: "noname@example.com"
+    }
+
+    result = Validation.result(params, name_email_schema)
+
+    assert result.errors == %{}
+    assert result.data == %{email: "noname@example.com"}
+  end
 end

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -42,8 +42,19 @@ defmodule ValidationTest do
     assert Result.valid?(result) == false
   end
 
-  @tag :skip
-  test "whitelisting params"
+  test "whitelisting params" do
+    params = %{
+      name: "Chuck Norris",
+      email: "gmail@chucknorris.com",
+      other: "thing"
+    }
+
+    result = Validation.result(params, name_email_schema)
+
+    assert result.errors == %{}
+    assert result.data == %{name: "Chuck Norris", email: "gmail@chucknorris.com"}
+  end
+
   @tag :skip
   test "optional params"
 end


### PR DESCRIPTION
* Added very simple validation with a few built-in predicates.
* Use as whitelist: Removes param keys with no rules
* Validate required keys

It is now possible to do:

```elixir
require Validation

schema = Validation.schema do
  optional(:name, filled? and type?(:string))
  required(:email, filled? and type?(:string) and match?(~r/@/))
end
params = %{name: "Me", email: "Not an email", foo: "bar"}
Validation.result(params, schema)
```

Will result in:
```elixir
%Validation.Result{
  data: %{email: "Not an email", name: "Me"},
  errors: %{email: ["is invalid"]}
}
```