### PR TITLE
First take at a simple Schema, 4

### DIFF
--- a/lib/validation/predicate.ex
+++ b/lib/validation/predicate.ex
@@ -43,6 +43,14 @@ defmodule Validation.Predicate do
   end
 
   @doc """
+  Applies the predicate to the given value.
+  Returns :ok or {:error, message}
+  """
+  def apply(%__MODULE__{val: val}, value) do
+    val.(value)
+  end
+
+  @doc """
   Built-in and
   """
   def built_in("and", left, right) do

--- a/lib/validation/result.ex
+++ b/lib/validation/result.ex
@@ -5,10 +5,14 @@ defmodule Validation.Result do
 
   defstruct [
     data: %{},
-    errors: %{}
+    errors: %{},
+    valid?: true
   ]
 
   def put_error(%__MODULE__{} = result, key, message) do
-    %{result | errors: Map.update(result.errors, key, [message], fn messages -> [message | messages] end)}
+    %{result |
+      errors: Map.update(result.errors, key, [message], fn messages -> [message | messages] end),
+      valid?: false
+    }
   end
 end

--- a/lib/validation/rule.ex
+++ b/lib/validation/rule.ex
@@ -22,6 +22,14 @@ defmodule Validation.Rule do
   end
 
   @doc """
+  Applies the rule to the given result.
+  Returns an updated result
+  """
+  def apply(%__MODULE__{val: val}, result) do
+    val.(result)
+  end
+
+  @doc """
   Built-in rule that validates a single value by key and a predicate
   """
   def built_in("value", key, predicate) do

--- a/lib/validation/rule.ex
+++ b/lib/validation/rule.ex
@@ -3,6 +3,7 @@ defmodule Validation.Rule do
   A rule accepts a %Result{} and returns an updated %Result{}
   """
 
+  alias Validation.Predicate
   alias Validation.Result
 
   defstruct [
@@ -34,10 +35,8 @@ defmodule Validation.Rule do
   """
   def built_in("value", key, predicate) do
     val = fn result ->
-      result.data
-      |> Map.get(key)
-      |> predicate.val.()
-      |> case do
+      value = Map.get(result.data, key)
+      case Predicate.apply(predicate, value) do
         :ok -> result
         {:error, message} -> Result.put_error(result, key, message)
       end

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -5,6 +5,7 @@ defmodule Validation.Schema do
   """
 
   alias Validation.Result
+  alias Validation.Rule
 
   defstruct [
     val: nil,
@@ -14,10 +15,7 @@ defmodule Validation.Schema do
   def build(rules) do
     val = fn params ->
       result = %Result{data: params}
-      rules
-      |> Enum.reduce(result, fn rule, result ->
-        rule.val.(result)
-      end)
+      Enum.reduce(rules, result, &Rule.apply/2)
     end
 
     %__MODULE__{val: val, meta: [rules: rules]}

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -12,6 +12,9 @@ defmodule Validation.Schema do
     meta: []
   ]
 
+  @doc """
+  Builds a schema from a list of rules
+  """
   def build(rules) do
     val = fn params ->
       result = %Result{data: params}
@@ -19,5 +22,13 @@ defmodule Validation.Schema do
     end
 
     %__MODULE__{val: val, meta: [rules: rules]}
+  end
+
+  @doc """
+  Applies the schema to a params map.
+  Returns a %Result{} struct
+  """
+  def apply(%__MODULE__{val: val}, params) do
+    val.(params)
   end
 end

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -1,0 +1,25 @@
+defmodule Validation.Schema do
+  @moduledoc """
+  A Schema is a collection of rules that each are applied to the given params.
+  The result of evaluating a params map against a schema is a %Result{} struct.
+  """
+
+  alias Validation.Result
+
+  defstruct [
+    val: nil,
+    meta: []
+  ]
+
+  def build(rules) do
+    val = fn params ->
+      result = %Result{data: params}
+      rules
+      |> Enum.reduce(result, fn rule, result ->
+        rule.val.(result)
+      end)
+    end
+
+    %__MODULE__{val: val, meta: [rules: rules]}
+  end
+end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -17,7 +17,7 @@ defmodule Validation.SchemaTest do
 
   test "simple schema against invalid data" do
     params = %{name: ""}
-    result = simple_schema.val.(params)
+    result = Schema.apply(simple_schema, params)
 
     assert result.valid? == false
     assert result.data == %{name: ""}
@@ -26,7 +26,7 @@ defmodule Validation.SchemaTest do
 
   test "simple schema against valid data" do
     params = %{name: "John"}
-    result = simple_schema.val.(params)
+    result = Schema.apply(simple_schema, params)
 
     assert result.valid? == true
     assert result.data == %{name: "John"}

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -1,0 +1,20 @@
+defmodule Validation.SchemaTest do
+  use ExUnit.Case, async: true
+
+  alias Validation.Predicate
+  alias Validation.Rule
+  alias Validation.Schema
+
+  test "using a simple schema" do
+    schema = Schema.build([Rule.built_in("value", :name, Predicate.built_in("filled?"))])
+
+    assert schema.meta[:rules] |> length == 1
+
+    params = %{name: ""}
+    result = schema.val.(params)
+
+    assert result.valid? == false
+    assert result.data == %{name: ""}
+    assert result.errors == %{name: ["must be filled"]}
+  end
+end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -5,16 +5,31 @@ defmodule Validation.SchemaTest do
   alias Validation.Rule
   alias Validation.Schema
 
-  test "using a simple schema" do
-    schema = Schema.build([Rule.built_in("value", :name, Predicate.built_in("filled?"))])
+  def simple_schema do
+    Schema.build([Rule.built_in("value", :name, Predicate.built_in("filled?"))])
+  end
 
-    assert schema.meta[:rules] |> length == 1
+  test "simple schema has metadata" do
+    schema = simple_schema
 
+    assert [%Rule{}] = schema.meta[:rules]
+  end
+
+  test "simple schema against invalid data" do
     params = %{name: ""}
-    result = schema.val.(params)
+    result = simple_schema.val.(params)
 
     assert result.valid? == false
     assert result.data == %{name: ""}
     assert result.errors == %{name: ["must be filled"]}
+  end
+
+  test "simple schema against valid data" do
+    params = %{name: "John"}
+    result = simple_schema.val.(params)
+
+    assert result.valid? == true
+    assert result.data == %{name: "John"}
+    assert result.errors == %{}
   end
 end


### PR DESCRIPTION
Ref #4 

A simple schema. It can be build from a list of rules.

Example of a simple schema that only validates that the value of `:name` is filled:

```elixir
schema = Schema.build([Rule.built_in("value", :name, Predicate.built_in("filled?"))])

params = %{name: ""}
result = schema.val.(params)

assert result.valid? == false
assert result.data == %{name: ""}
assert result.errors == %{name: ["must be filled"]}
```

The schema structure looks like this:

```elixir
%Validation.Schema{
  meta: [
    rules: [
      %Validation.Rule{
        meta: [
          type: "value",
          key: :name,
          predicate: %Validation.Predicate{
            meta: [type: "basic", name: "filled?", message: "must be filled"],
            val: #Function<1.42827446/1 in Validation.Predicate.build_basic/3>
          }
        ],
        val: #Function<2.100964708/1 in Validation.Rule.built_in/3>
      }
    ]
  ],
  val: #Function<1.96799137/1 in Validation.Schema.build/1>
}
```

Notice how each "piece" of the schema has it's own `val` function. This is the compiled validator function. The schema `val` uses the rule `val`, which in turn uses the predicate `val`.