### PR TITLE
Add dialyze

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,8 +18,10 @@ dependencies:
     - mix local.hex --force
     - mix local.rebar --force
     - mix deps.get
+    - MIX_ENV=test mix compile
+    - MIX_ENV=test mix dialyzer
 test:
   override:
     - mix test
-    - mix credo
-    - mix dialyzer --halt-exit-status
+    - MIX_ENV=test mix credo
+    - MIX_ENV=test mix dialyzer --halt-exit-status

--- a/circle.yml
+++ b/circle.yml
@@ -22,3 +22,4 @@ test:
   override:
     - mix test
     - mix credo
+    - mix dialyzer --halt-exit-status

--- a/lib/validation/predicate.ex
+++ b/lib/validation/predicate.ex
@@ -4,9 +4,9 @@ defmodule Validation.Predicate do
   and returns either :ok or {:error, message}
   """
 
-  @type  t            :: %__MODULE__{ val: compiled_fun, meta: meta_data }
+  @type  t            :: %__MODULE__{val: compiled_fun, meta: meta_data}
   @type  result       :: :ok | {:error, String.t}
-  @typep compiled_fun :: ((Any.t) -> result)
+  @typep compiled_fun :: ((any) -> result)
   @typep meta_data    :: Keyword.t
 
   defstruct [
@@ -31,7 +31,7 @@ defmodule Validation.Predicate do
   The supplied fun should return true or false
   """
 
-  @type predicate_fun :: ((Any.t) -> boolean)
+  @type predicate_fun :: ((any) -> boolean)
   @spec build_basic(predicate_fun, String.t, String.t) :: t
   def build_basic(fun, message, name) do
     val = fn value ->
@@ -60,7 +60,7 @@ defmodule Validation.Predicate do
   Applies the predicate to the given value.
   Returns :ok or {:error, message}
   """
-  @spec apply(t, Ant.t) :: result
+  @spec apply(t, any) :: result
   def apply(%__MODULE__{val: val}, value) do
     val.(value)
   end

--- a/lib/validation/predicate.ex
+++ b/lib/validation/predicate.ex
@@ -31,7 +31,7 @@ defmodule Validation.Predicate do
   The supplied fun should return true or false
   """
 
-  @type predicate_fun :: ((any) -> boolean)
+  @typep predicate_fun :: ((any) -> boolean)
   @spec build_basic(predicate_fun, String.t, String.t) :: t
   def build_basic(fun, message, name) do
     val = fn value ->
@@ -49,7 +49,7 @@ defmodule Validation.Predicate do
   Builds a predicate by composing multiple other predicates
   """
 
-  @type composer :: (([t]) -> compiled_fun)
+  @typep composer :: (([t]) -> compiled_fun)
   @spec build_composed([t], composer, String.t) :: t
   def build_composed(predicates, composer, name) do
     val = composer.(predicates)

--- a/lib/validation/result.ex
+++ b/lib/validation/result.ex
@@ -3,7 +3,7 @@ defmodule Validation.Result do
   The result of a validation. It contains the final data and errors.
   """
 
-  @type t :: %__MODULE__{data: Map.t, errors: Map.t, valid?: boolean}
+  @type t :: %__MODULE__{data: map, errors: map, valid?: boolean}
 
   defstruct [
     data: %{},

--- a/lib/validation/result.ex
+++ b/lib/validation/result.ex
@@ -3,12 +3,15 @@ defmodule Validation.Result do
   The result of a validation. It contains the final data and errors.
   """
 
+  @type t :: %__MODULE__{ data: Map.t, errors: Map.t, valid?: Bool.t }
+
   defstruct [
     data: %{},
     errors: %{},
     valid?: true
   ]
 
+  @spec put_error(t, Any.t, String.t) :: t
   def put_error(%__MODULE__{} = result, key, message) do
     %{result |
       errors: Map.update(result.errors, key, [message], fn messages -> [message | messages] end),

--- a/lib/validation/result.ex
+++ b/lib/validation/result.ex
@@ -3,7 +3,7 @@ defmodule Validation.Result do
   The result of a validation. It contains the final data and errors.
   """
 
-  @type t :: %__MODULE__{ data: Map.t, errors: Map.t, valid?: Bool.t }
+  @type t :: %__MODULE__{data: Map.t, errors: Map.t, valid?: boolean}
 
   defstruct [
     data: %{},
@@ -11,7 +11,7 @@ defmodule Validation.Result do
     valid?: true
   ]
 
-  @spec put_error(t, Any.t, String.t) :: t
+  @spec put_error(t, any, String.t) :: t
   def put_error(%__MODULE__{} = result, key, message) do
     %{result |
       errors: Map.update(result.errors, key, [message], fn messages -> [message | messages] end),

--- a/lib/validation/rule.ex
+++ b/lib/validation/rule.ex
@@ -6,9 +6,9 @@ defmodule Validation.Rule do
   alias Validation.Predicate
   alias Validation.Result
 
-  @type t         :: %__MODULE__{val: rule_fun, meta: meta_data}
-  @type rule_fun  :: ((Result.t) -> Result.t)
-  @type meta_data :: Keyword.t
+  @type t          :: %__MODULE__{val: rule_fun, meta: meta_data}
+  @typep rule_fun  :: ((Result.t) -> Result.t)
+  @typep meta_data :: Keyword.t
 
   defstruct [
     val: nil,

--- a/lib/validation/rule.ex
+++ b/lib/validation/rule.ex
@@ -6,7 +6,7 @@ defmodule Validation.Rule do
   alias Validation.Predicate
   alias Validation.Result
 
-  @type t         :: %__MODULE__{ val: rule_fun, meta: meta_data }
+  @type t         :: %__MODULE__{val: rule_fun, meta: meta_data}
   @type rule_fun  :: ((Result.t) -> Result.t)
   @type meta_data :: Keyword.t
 
@@ -39,7 +39,7 @@ defmodule Validation.Rule do
   @doc """
   Built-in rule that validates a single value by key and a predicate
   """
-  @spec built_in(String.t, Any.t, Predicate.t) :: t
+  @spec built_in(String.t, any, Predicate.t) :: t
   def built_in("value", key, predicate) do
     val = fn result ->
       value = Map.get(result.data, key)
@@ -55,7 +55,7 @@ defmodule Validation.Rule do
   @doc """
   Build a rule that requires a certain key to be present
   """
-  @spec built_in(String.t, Any.t) :: t
+  @spec built_in(String.t, any) :: t
   def built_in("required", key) do
     val = fn result ->
       result.data

--- a/lib/validation/rule.ex
+++ b/lib/validation/rule.ex
@@ -6,6 +6,10 @@ defmodule Validation.Rule do
   alias Validation.Predicate
   alias Validation.Result
 
+  @type t         :: %__MODULE__{ val: rule_fun, meta: meta_data }
+  @type rule_fun  :: ((Result.t) -> Result.t)
+  @type meta_data :: Keyword.t
+
   defstruct [
     val: nil,
     meta: []
@@ -15,6 +19,7 @@ defmodule Validation.Rule do
   Build a custom rule from just a function.
   The function must accept a %Result and return an updated %Result{}
   """
+  @spec build(rule_fun, meta_data) :: t
   def build(val, meta \\ []) do
     %__MODULE__{
       val: val,
@@ -26,6 +31,7 @@ defmodule Validation.Rule do
   Applies the rule to the given result.
   Returns an updated result
   """
+  @spec apply(t, Result.t) :: Result.t
   def apply(%__MODULE__{val: val}, result) do
     val.(result)
   end
@@ -33,6 +39,7 @@ defmodule Validation.Rule do
   @doc """
   Built-in rule that validates a single value by key and a predicate
   """
+  @spec built_in(String.t, Any.t, Predicate.t) :: t
   def built_in("value", key, predicate) do
     val = fn result ->
       value = Map.get(result.data, key)
@@ -48,6 +55,7 @@ defmodule Validation.Rule do
   @doc """
   Build a rule that requires a certain key to be present
   """
+  @spec built_in(String.t, Any.t) :: t
   def built_in("required", key) do
     val = fn result ->
       result.data

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -8,7 +8,7 @@ defmodule Validation.Schema do
   alias Validation.Rule
 
   @type t           :: %__MODULE__{val: schema_fun, meta: meta_data}
-  @typep schema_fun :: ((any) -> Result.t)
+  @typep schema_fun :: ((map) -> Result.t)
   @typep meta_data  :: Keyword.t
 
   defstruct [
@@ -33,7 +33,7 @@ defmodule Validation.Schema do
   Applies the schema to a params map.
   Returns a %Result{} struct
   """
-  @spec apply(t, any) :: Result.t
+  @spec apply(t, map) :: Result.t
   def apply(%__MODULE__{val: val}, params) do
     val.(params)
   end

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -7,6 +7,10 @@ defmodule Validation.Schema do
   alias Validation.Result
   alias Validation.Rule
 
+  @type t           :: %__MODULE__{ val: schema_fun, meta: meta_data }
+  @typep schema_fun :: ((Any.t) -> Result.t)
+  @typep meta_data  :: Keyword.t
+
   defstruct [
     val: nil,
     meta: []
@@ -15,6 +19,7 @@ defmodule Validation.Schema do
   @doc """
   Builds a schema from a list of rules
   """
+  @spec build([Rule.t]) :: t
   def build(rules) do
     val = fn params ->
       result = %Result{data: params}
@@ -28,6 +33,7 @@ defmodule Validation.Schema do
   Applies the schema to a params map.
   Returns a %Result{} struct
   """
+  @spec apply(t, Any.t) :: Result.t
   def apply(%__MODULE__{val: val}, params) do
     val.(params)
   end

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -7,8 +7,8 @@ defmodule Validation.Schema do
   alias Validation.Result
   alias Validation.Rule
 
-  @type t           :: %__MODULE__{ val: schema_fun, meta: meta_data }
-  @typep schema_fun :: ((Any.t) -> Result.t)
+  @type t           :: %__MODULE__{val: schema_fun, meta: meta_data}
+  @typep schema_fun :: ((any) -> Result.t)
   @typep meta_data  :: Keyword.t
 
   defstruct [
@@ -33,7 +33,7 @@ defmodule Validation.Schema do
   Applies the schema to a params map.
   Returns a %Result{} struct
   """
-  @spec apply(t, Any.t) :: Result.t
+  @spec apply(t, any) :: Result.t
   def apply(%__MODULE__{val: val}, params) do
     val.(params)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Validation.Mixfile do
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
+      dialyzer: [plt_add_deps: :transitive],
       deps: deps()
     ]
   end
@@ -35,7 +36,7 @@ defmodule Validation.Mixfile do
   defp deps do
     [
       {:credo, "~> 0.5", only: [:dev, :test]},
-      {:dialyze, "~> 0.2", only: [:dev, :test]}
+      {:dialyxir, "~> 0.4", only: [:dev, :test]}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,8 @@ defmodule Validation.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:credo, "~> 0.5", only: [:dev, :test]}
+      {:credo, "~> 0.5", only: [:dev, :test]},
+      {:dialyze, "~> 0.2", only: [:dev, :test]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,3 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
-  "dialyxir": {:hex, :dialyxir, "0.4.0", "53ac3014bb4aef647728a697052b4db3a84c6742de7aab0e0a1c863ea274007b", [:mix], []},
-  "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []}}
+  "dialyxir": {:hex, :dialyxir, "0.4.0", "53ac3014bb4aef647728a697052b4db3a84c6742de7aab0e0a1c863ea274007b", [:mix], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]}}
+  "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.4.0", "53ac3014bb4aef647728a697052b4db3a84c6742de7aab0e0a1c863ea274007b", [:mix], []},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []}}


### PR DESCRIPTION
This adds type specs to all exported(public) functions. Additionally I added the dialyze package
that provides a handy mix task to verify the type specs like so:

```
$ mix dialyze
```

Running it for the first time, takes some time but subsequent runs are faster.

Please have a look :)

Refs: https://github.com/lasseebert/validation/issues/11