### PR TITLE
21 preprocessor

### DIFF
--- a/lib/validation/preprocessor.ex
+++ b/lib/validation/preprocessor.ex
@@ -1,0 +1,37 @@
+defmodule Validation.Preprocessor do
+  @moduledoc """
+  A Preprocessor transforms a params map.
+
+  In a schema, an ordered list of preprocessors is applied before the rules.
+  """
+
+  @type t :: %__MODULE__{val: preprocessor_fun, meta: meta_data}
+  @typep params :: map
+  @typep preprocessor_fun :: ((params) -> params)
+  @typep meta_data :: Keyword.t
+
+  defstruct [
+    val: nil,
+    meta: []
+  ]
+
+  @doc """
+  Builds a custom preprocessor from a function and optionally some meta data.
+  The function accepts a params map and returns an updated params map
+  """
+  @spec build(preprocessor_fun, meta_data) :: t
+  def build(val, meta \\ []) do
+    %__MODULE__{
+      val: val,
+      meta: meta
+    }
+  end
+
+  @doc """
+  Applies the preprocessor to the given params map
+  """
+  @spec apply(t, params) :: params
+  def apply(%__MODULE__{val: val}, params) do
+    val.(params)
+  end
+end

--- a/lib/validation/preprocessor.ex
+++ b/lib/validation/preprocessor.ex
@@ -5,6 +5,8 @@ defmodule Validation.Preprocessor do
   In a schema, an ordered list of preprocessors is applied before the rules.
   """
 
+  import Kernel, except: [apply: 2]
+
   @type t :: %__MODULE__{val: preprocessor_fun, meta: meta_data}
   @typep params :: map
   @typep preprocessor_fun :: ((params) -> params)
@@ -33,5 +35,20 @@ defmodule Validation.Preprocessor do
   @spec apply(t, params) :: params
   def apply(%__MODULE__{val: val}, params) do
     val.(params)
+  end
+
+  @doc """
+  Combines multiple preprocessors into a single preprocessor.
+  The resulting preprocessor applies each given preprocessor in serial.
+  """
+  @spec combine([t]) :: t
+  def combine(preprocessors) do
+    val = fn params ->
+      preprocessors
+      |> Enum.reduce(params, fn preprocessor, params ->
+        apply(preprocessor, params)
+      end)
+    end
+    build(val, type: "combined", preprocessors: preprocessors)
   end
 end

--- a/lib/validation/preprocessor.ex
+++ b/lib/validation/preprocessor.ex
@@ -51,4 +51,13 @@ defmodule Validation.Preprocessor do
     end
     build(val, type: "combined", preprocessors: preprocessors)
   end
+
+  @doc """
+  The preprocessor that returns the input params untouched.
+  This can be used as a default preprocessor.
+  """
+  @spec identity() :: t
+  def identity do
+    build(&(&1), type: "identity")
+  end
 end

--- a/lib/validation/result.ex
+++ b/lib/validation/result.ex
@@ -18,4 +18,20 @@ defmodule Validation.Result do
       valid?: false
     }
   end
+
+  @spec merge_errors(t, map) :: t
+  @doc """
+  Merges the given errors with the errors in the result.
+  Returns an updated result
+  """
+  def merge_errors(%__MODULE__{} = result, errors) do
+    updated_errors = Map.merge(result.errors, errors, fn _key, v1, v2 ->
+      Enum.uniq(v1 ++ v2)
+    end)
+
+    %{result |
+      errors: updated_errors,
+      valid?: !Enum.any?(updated_errors)
+    }
+  end
 end

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -31,7 +31,7 @@ defmodule Validation.Schema do
       end)
     end
 
-    %__MODULE__{val: val, meta: [rules: rules]}
+    %__MODULE__{val: val, meta: [rules: rules, preprocessor: preprocessor]}
   end
 
   @doc """

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -4,6 +4,7 @@ defmodule Validation.Schema do
   The result of evaluating a params map against a schema is a %Result{} struct.
   """
 
+  alias Validation.Preprocessor
   alias Validation.Result
   alias Validation.Rule
 
@@ -17,11 +18,12 @@ defmodule Validation.Schema do
   ]
 
   @doc """
-  Builds a schema from a list of rules
+  Builds a schema from a list of rules and optionally a preprocessor
   """
-  @spec build([Rule.t]) :: t
-  def build(rules) do
+  @spec build([Rule.t], Preprocessor.t) :: t
+  def build(rules, preprocessor \\ Preprocessor.identity) do
     val = fn params ->
+      params = Preprocessor.apply(preprocessor, params)
       result = %Result{data: params}
       Enum.reduce(rules, result, fn rule, result ->
         errors = Rule.apply(rule, result.data)

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -23,7 +23,10 @@ defmodule Validation.Schema do
   def build(rules) do
     val = fn params ->
       result = %Result{data: params}
-      Enum.reduce(rules, result, &Rule.apply/2)
+      Enum.reduce(rules, result, fn rule, result ->
+        errors = Rule.apply(rule, result.data)
+        Result.merge_errors(result, errors)
+      end)
     end
 
     %__MODULE__{val: val, meta: [rules: rules]}

--- a/test/preprocessor_test.exs
+++ b/test/preprocessor_test.exs
@@ -1,0 +1,21 @@
+defmodule Validation.PreprocessorTest do
+  use ExUnit.Case, async: true
+
+  alias Validation.Preprocessor
+
+  test "building a preprocessor manually" do
+    fun = fn params ->
+      params
+      |> Enum.map(fn {key, value} -> {key, value |> String.upcase} end)
+      |> Enum.into(%{})
+    end
+
+    preprocessor = Preprocessor.build(fun, name: "My preprocessor")
+    assert preprocessor.meta == [name: "My preprocessor"]
+
+    params = %{name: "John"}
+    processed = Preprocessor.apply(preprocessor, params)
+
+    assert processed == %{name: "JOHN"}
+  end
+end

--- a/test/preprocessor_test.exs
+++ b/test/preprocessor_test.exs
@@ -43,4 +43,11 @@ defmodule Validation.PreprocessorTest do
 
     assert processed == %{name: "JOHN"}
   end
+
+  test "identity preprocessor" do
+    identity = Preprocessor.identity
+    params = %{name: "John"}
+
+    assert Preprocessor.apply(identity, params) == params
+  end
 end

--- a/test/preprocessor_test.exs
+++ b/test/preprocessor_test.exs
@@ -18,4 +18,29 @@ defmodule Validation.PreprocessorTest do
 
     assert processed == %{name: "JOHN"}
   end
+
+  test "combining preprocessors" do
+    upcaser = Preprocessor.build(fn params ->
+      params |>
+      Enum.map(fn {key, value} -> {key, value |> String.upcase} end)
+      |> Enum.into(%{})
+    end, name: "upcaser")
+    x_remover = Preprocessor.build(fn params ->
+      params
+      |> Enum.reject(fn {key, _value} -> key |> inspect |> String.match?(~r/x/) end)
+      |> Enum.into(%{})
+    end, name: "x_remover")
+
+    combined = Preprocessor.combine([upcaser, x_remover])
+
+    assert combined.meta[:preprocessors] |> Enum.map(&(&1.meta)) == [[name: "upcaser"], [name: "x_remover"]]
+
+    params = %{
+      name: "John",
+      name_x: "Wayne"
+    }
+    processed = Preprocessor.apply(combined, params)
+
+    assert processed == %{name: "JOHN"}
+  end
 end

--- a/test/result_test.exs
+++ b/test/result_test.exs
@@ -1,0 +1,39 @@
+defmodule Validation.ResultTest do
+  use ExUnit.Case, async: true
+
+  alias Validation.Result
+
+  describe "merge_errors/2" do
+    test "merging no errors" do
+      result =
+        %Result{errors: %{name: ["is missing"]}}
+        |> Result.merge_errors(%{})
+
+      assert result.errors == %{name: ["is missing"]}
+    end
+
+    test "merging into empty errors" do
+      result =
+        %Result{}
+        |> Result.merge_errors(%{name: ["is missing"]})
+
+      assert result.errors == %{name: ["is missing"]}
+    end
+
+    test "merging errors with same key" do
+      result =
+        %Result{errors: %{name: ["is invalid"]}}
+        |> Result.merge_errors(%{name: ["is missing"]})
+
+      assert result.errors == %{name: ["is invalid", "is missing"]}
+    end
+
+    test "merging errors with same key and message" do
+      result =
+        %Result{errors: %{name: ["is missing"]}}
+        |> Result.merge_errors(%{name: ["is missing"]})
+
+      assert result.errors == %{name: ["is missing"]}
+    end
+  end
+end

--- a/test/rule_test.exs
+++ b/test/rule_test.exs
@@ -2,45 +2,44 @@ defmodule Validation.RuleTest do
   use ExUnit.Case, async: true
 
   alias Validation.Predicate
-  alias Validation.Result
   alias Validation.Rule
 
   test "building a simple custom rule" do
-    val = fn result ->
-      if result.data[:name] do
-        result
+    val = fn params ->
+      if params[:name] do
+        %{}
       else
-        Result.put_error(result, :name, "must be filled")
+        %{name: ["must be filled"]}
       end
     end
 
     rule = Rule.build(val, name: ["name must be filled"])
 
-    result = %Result{data: %{name: "Me"}} |> rule.val.()
-    assert result.errors == %{}
+    errors = Rule.apply(rule, %{name: "Me"})
+    assert errors == %{}
 
-    result = %Result{data: %{}} |> rule.val.()
-    assert result.errors == %{name: ["must be filled"]}
+    errors = Rule.apply(rule, %{})
+    assert errors == %{name: ["must be filled"]}
   end
 
   test "built-in value rule" do
     filled? = Predicate.build_basic(fn value -> !(value in ["", nil]) end, "must be filled", "filled?")
     rule = Rule.built_in("value", :name, filled?)
 
-    result = %Result{data: %{name: "Me"}} |> rule.val.()
-    assert result.errors == %{}
+    errors = Rule.apply(rule, %{name: "Me"})
+    assert errors == %{}
 
-    result = %Result{data: %{}} |> rule.val.()
-    assert result.errors == %{name: ["must be filled"]}
+    errors = Rule.apply(rule, %{})
+    assert errors == %{name: ["must be filled"]}
   end
 
   test "built_in required rule" do
     rule = Rule.built_in("required", :name)
 
-    result = %Result{data: %{name: "Me"}} |> rule.val.()
-    assert result.errors == %{}
+    errors = Rule.apply(rule, %{name: "Me"})
+    assert errors == %{}
 
-    result = %Result{data: %{}} |> rule.val.()
-    assert result.errors == %{name: ["is missing"]}
+    errors = Rule.apply(rule, %{})
+    assert errors == %{name: ["is missing"]}
   end
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -52,5 +52,7 @@ defmodule Validation.SchemaTest do
     assert result.valid? == true
     assert result.data == %{name: "JOHN"}
     assert result.errors == %{}
+
+    assert schema.meta[:preprocessor] == upcaser
   end
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -2,6 +2,7 @@ defmodule Validation.SchemaTest do
   use ExUnit.Case, async: true
 
   alias Validation.Predicate
+  alias Validation.Preprocessor
   alias Validation.Rule
   alias Validation.Schema
 
@@ -30,6 +31,26 @@ defmodule Validation.SchemaTest do
 
     assert result.valid? == true
     assert result.data == %{name: "John"}
+    assert result.errors == %{}
+  end
+
+  test "schema with preprocessor" do
+    upcaser = Preprocessor.build(fn params ->
+      params |>
+      Enum.map(fn {key, value} -> {key, value |> String.upcase} end)
+      |> Enum.into(%{})
+    end)
+
+    schema = Schema.build(
+      [Rule.built_in("value", :name, Predicate.built_in("filled?"))],
+      upcaser
+    )
+
+    params = %{name: "John"}
+    result = Schema.apply(schema, params)
+
+    assert result.valid? == true
+    assert result.data == %{name: "JOHN"}
     assert result.errors == %{}
   end
 end


### PR DESCRIPTION
Closes #21 

* Removed Rule's ability to change input params and existing errors.
* Added the concept of preprocessors and added to schema.
* Added a single built-in preprocessor, `identity`, which is used as default. It does nothing.
* Added ability to combine multiple preprocessors into one.
