### PR TITLE
Simple nested schema support, 12

### DIFF
--- a/lib/validation/result.ex
+++ b/lib/validation/result.ex
@@ -19,11 +19,11 @@ defmodule Validation.Result do
     }
   end
 
-  @spec merge_errors(t, map) :: t
   @doc """
   Merges the given errors with the errors in the result.
   Returns an updated result
   """
+  @spec merge_errors(t, map) :: t
   def merge_errors(%__MODULE__{} = result, errors) do
     updated_errors = Map.merge(result.errors, errors, fn _key, v1, v2 ->
       Enum.uniq(v1 ++ v2)
@@ -33,5 +33,15 @@ defmodule Validation.Result do
       errors: updated_errors,
       valid?: !Enum.any?(updated_errors)
     }
+  end
+
+  @doc """
+  Merges a nested result with the given key
+  """
+  @spec merge_nested(result :: t, nested :: t, key :: any) :: t
+  def merge_nested(result, nested, key) do
+    data = Map.put(result.data, key, nested.data)
+    errors = Map.put(result.errors, key, nested.errors)
+    %{result | data: data, errors: errors, valid?: result.valid? && nested.valid?}
   end
 end

--- a/lib/validation/schema.ex
+++ b/lib/validation/schema.ex
@@ -77,9 +77,11 @@ defmodule Validation.Schema do
       result.data
       |> Map.fetch(key)
       |> case do
-        {:ok, nested_params} ->
+        {:ok, %{} = nested_params} ->
           nested_result = apply(nested_schema, nested_params)
           Result.merge_nested(result, nested_result, key)
+        {:ok, _not_map} ->
+          Result.merge_errors(result, %{key => ["is invalid"]})
         :error ->
           result
       end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -8,7 +8,7 @@ defmodule Validation.SchemaTest do
   alias Validation.Schema
 
   def simple_schema do
-    Schema.build([Rules.Value.build(:name, Predicates.Filled.build())])
+    Schema.build([Rules.Value.build(:name, Predicates.Filled.build())], %{})
   end
 
   test "simple schema has metadata" do
@@ -44,6 +44,7 @@ defmodule Validation.SchemaTest do
 
     schema = Schema.build(
       [Rules.Value.build(:name, Predicates.Filled.build())],
+      %{},
       preprocessor: upcaser
     )
 
@@ -62,7 +63,7 @@ defmodule Validation.SchemaTest do
       Rules.Value.build(:name, Predicates.Filled.build()),
       Rules.Value.build(:email, Predicates.Filled.build()),
     ]
-    schema = Schema.build(rules, strict: true)
+    schema = Schema.build(rules, %{}, strict: true)
 
     assert schema.meta[:rules] |> length == 3
     assert schema.meta[:rules] |> hd |> Map.get(:meta) |> Keyword.get(:type) == "strict"
@@ -81,12 +82,37 @@ defmodule Validation.SchemaTest do
       Rules.Value.build(:name, Predicates.Filled.build()),
       Rules.Value.build(:email, Predicates.Filled.build()),
     ]
-    schema = Schema.build(rules, whitelist: true)
+    schema = Schema.build(rules, %{}, whitelist: true)
 
     assert schema.meta[:preprocessor].meta[:type] == "combined"
 
     params = %{name: "me", email: "me@example.com", age: 42}
     result = Schema.apply(schema, params)
     assert result.data == %{name: "me", email: "me@example.com"}
+  end
+
+  test "nested schema" do
+    rules = [Rules.Value.build(:name, Predicates.Filled.build())]
+    nested_schema = Schema.build(rules, %{})
+    schema = Schema.build([], %{user: nested_schema})
+
+    params = %{user: %{name: ""}}
+    result = Schema.apply(schema, params)
+    assert result.data == %{user: %{name: ""}}
+    assert result.valid? == false
+    assert result.errors == %{user: %{name: ["must be filled"]}}
+  end
+
+  test "deeply nested schema" do
+    rules = [Rules.Value.build(:name, Predicates.Filled.build())]
+    user_schema = Schema.build(rules, %{})
+    attrs_schema = Schema.build([], %{user: user_schema})
+    schema = Schema.build([], %{attrs: attrs_schema})
+
+    params = %{attrs: %{user: %{name: ""}}}
+    result = Schema.apply(schema, params)
+    assert result.data == %{attrs: %{user: %{name: ""}}}
+    assert result.valid? == false
+    assert result.errors == %{attrs: %{user: %{name: ["must be filled"]}}}
   end
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -115,4 +115,16 @@ defmodule Validation.SchemaTest do
     assert result.valid? == false
     assert result.errors == %{attrs: %{user: %{name: ["must be filled"]}}}
   end
+
+  test "nested schema when nested value is not a map" do
+    rules = [Rules.Value.build(:name, Predicates.Filled.build())]
+    nested_schema = Schema.build(rules, %{})
+    schema = Schema.build([], %{user: nested_schema})
+
+    params = %{user: "Not a map"}
+    result = Schema.apply(schema, params)
+    assert result.data == %{user: "Not a map"}
+    assert result.valid? == false
+    assert result.errors == %{user: ["is invalid"]}
+  end
 end


### PR DESCRIPTION
Ref #12 

A first take on nested schemas. This is still a WIP and is meant as a reference for discussion.
A nested schema is just a schema that is applied to only a subtree of the params. Having it as "just a schema" makes it simple to compose different schemas.

Can do:

* Define simple nested schemas. See the new tests.

Uncertain:

* Should a nested schema be allowed to have it's own preprocessor? I think yes.
* Are the nested errors in a good format?
* What if key for nested schema is not present in the params? (Right now, the nested schema is just skipped in that case, since a required-key rule could be applied if needed)
* ~~What if the value of the nested key is not a map. Should probably give a nice error message in that case.~~ Edit: Added an error message

Please review and comment :)